### PR TITLE
Fix default bookmark text

### DIFF
--- a/bookmarks/signals.py
+++ b/bookmarks/signals.py
@@ -19,7 +19,7 @@ def create_default_collection(sender, instance, created, **kwargs):
         # Add a default bookmark
         Bookmark.objects.create(
             url="https://github.com",
-            display_name="Github",
+            display_name="GitHub",
             notes="",
             category=category,
-        )        
+        )


### PR DESCRIPTION
## Summary
- fix GitHub casing in the default bookmark

## Testing
- `python3 -m py_compile bookmarks/signals.py`

------
https://chatgpt.com/codex/tasks/task_e_684174f8ef08832b883930d1281d99f6