### PR TITLE
Fix home view collection access check

### DIFF
--- a/bookmarks/tests.py
+++ b/bookmarks/tests.py
@@ -1,3 +1,23 @@
 from django.test import TestCase
+from django.contrib.auth.models import User
+from django.urls import reverse
 
-# Create your tests here.
+from .models import Collection
+
+
+class HomeViewTest(TestCase):
+    def setUp(self):
+        self.user1 = User.objects.create_user(username="user1", password="pass")
+        self.user2 = User.objects.create_user(username="user2", password="pass")
+        self.collection1 = Collection.objects.create(
+            name="c1", owner=self.user1
+        )
+
+    def test_user_cannot_access_others_collection(self):
+        """Home view should return 404 for a collection not owned by the user."""
+        self.client.login(username="user2", password="pass")
+        response = self.client.get(
+            reverse("home"), {"collection": self.collection1.id}
+        )
+        self.assertEqual(response.status_code, 404)
+

--- a/bookmarks/views.py
+++ b/bookmarks/views.py
@@ -108,7 +108,11 @@ class NetscapeBookmarkParser(html.parser.HTMLParser):
 def home(request):
     collections = Collection.objects.filter(owner=request.user)
     selected_collection_id = request.GET.get('collection')
-    selected_collection = get_object_or_404(Collection, id=selected_collection_id) if selected_collection_id else collections.first()
+    selected_collection = (
+        get_object_or_404(Collection, id=selected_collection_id, owner=request.user)
+        if selected_collection_id
+        else collections.first()
+    )
     categories = Category.objects.filter(collection=selected_collection) if selected_collection else []
 
     # Prepare categories with bookmarks


### PR DESCRIPTION
## Summary
- restrict the `home` view to only fetch collections owned by the current user
- add regression test confirming this access control

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6841717693c4832b92c5652cff7bb583